### PR TITLE
chore: new eslint for react app

### DIFF
--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -12,7 +12,7 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v4
+      - uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/packages/example-react-app/.eslintrc.js
+++ b/packages/example-react-app/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  extends: '@chainsafe/eslint-config/frontend-react',
+  rules: {
+    '@typescript-eslint/explicit-function-return-type': 'off',
+    'operator-linebreak': 'off',
+  },
+};

--- a/packages/example-react-app/package.json
+++ b/packages/example-react-app/package.json
@@ -15,6 +15,7 @@
     "web3-plugin-wallet-rpc": "*"
   },
   "devDependencies": {
+    "@chainsafe/eslint-config": "^2.0.0",
     "@types/node": "^16.18.108",
     "@types/react": "^18.3.8",
     "@types/react-dom": "^18.3.0",
@@ -26,11 +27,6 @@
   "scripts": {
     "start": "react-scripts start",
     "lint": "eslint 'src/**/*.{js,ts,tsx}'"
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app"
-    ]
   },
   "browserslist": {
     "production": [

--- a/packages/example-react-app/src/App.tsx
+++ b/packages/example-react-app/src/App.tsx
@@ -1,14 +1,14 @@
 import { useContext, useEffect, useState } from 'react';
-import type { ProviderChainId, providers } from 'web3';
+import type { EIP6963ProviderDetail, ProviderChainId } from 'web3';
 
 import { Accounts } from './components/Accounts';
 import { ProviderButton } from './components/ProviderButton';
+import { AddEthereumChain } from './wallet-components/AddEthereumChain';
+import { Permissions } from './wallet-components/Permissions';
+import { SwitchEthereumChain } from './wallet-components/SwitchEthereumChain';
+import { WatchAsset } from './wallet-components/WatchAsset';
 import { AccountProvider } from './web3/AccountContext';
 import { type IWeb3Context, Web3Context } from './web3/Web3Context';
-import { SwitchEthereumChain } from './wallet-components/SwitchEthereumChain';
-import { AddEthereumChain } from './wallet-components/AddEthereumChain';
-import { WatchAsset } from './wallet-components/WatchAsset';
-import { Permissions } from './wallet-components/Permissions';
 
 function App() {
   const web3Context: IWeb3Context = useContext(Web3Context);
@@ -25,7 +25,7 @@ function App() {
       return;
     }
 
-    const provider = web3Context.currentProvider.provider;
+    const { provider } = web3Context.currentProvider;
 
     function updateChainId(newId: bigint) {
       setChainId(newId);
@@ -33,53 +33,80 @@ function App() {
 
     function updateProviderIds(newId: ProviderChainId) {
       setChainId(BigInt(newId));
-      web3Context.web3.eth.net.getId().then(setNetworkId);
+
+      web3Context.web3.eth.net
+        .getId()
+        .then(setNetworkId)
+        .catch((error) => {
+          // eslint-disable-next-line no-console
+          console.error(error);
+        });
     }
 
-    web3Context.web3.eth.getChainId().then(updateChainId);
-    web3Context.web3.eth.net.getId().then(setNetworkId);
+    web3Context.web3.eth
+      .getChainId()
+      .then(updateChainId)
+      .catch((error) => {
+        // eslint-disable-next-line no-console
+        console.error(error);
+      });
+
+    web3Context.web3.eth.net
+      .getId()
+      .then(setNetworkId)
+      .catch((error) => {
+        // eslint-disable-next-line no-console
+        console.error(error);
+      });
+
     provider.on('chainChanged', updateProviderIds);
-    return () => provider.removeListener('chainChanged', updateProviderIds);
+
+    // eslint-disable-next-line consistent-return
+    return () => {
+      provider.removeListener('chainChanged', updateProviderIds);
+    };
   }, [web3Context.currentProvider, web3Context.web3.eth]);
 
   return (
     <main>
       <h1>Web3.js Wallet RPC Methods Demonstration dApp</h1>
       <div>This is a sample project that demonstrates using web3-plugin-wallet-rpc.</div>
-      {!hasProviders ? (
-        <h2>Install a Wallet</h2>
-      ) : web3Context.currentProvider === undefined ? (
+
+      {!hasProviders && <h2>Install a Wallet</h2>}
+
+      {hasProviders && !web3Context.currentProvider && (
         <>
           <h2>Select a Provider</h2>
-          {web3Context.providers.map((provider: providers.EIP6963ProviderDetail) => {
-            return (
-              <div key={provider.info.uuid}>
-                <ProviderButton provider={provider}></ProviderButton>
-              </div>
-            );
-          })}
+          {web3Context.providers.map((provider: EIP6963ProviderDetail) => (
+            <div key={provider.info.uuid}>
+              <ProviderButton provider={provider} />
+            </div>
+          ))}
         </>
-      ) : (
+      )}
+
+      {hasProviders && web3Context.currentProvider && (
         <>
-          {web3Context.providers.length > 1 ? (
+          {web3Context.providers.length > 1 && (
             <>
               <h2>Switch Provider</h2>
-              {web3Context.providers.map((provider: providers.EIP6963ProviderDetail) => {
+              {web3Context.providers.map((provider: EIP6963ProviderDetail) => {
                 if (provider.info.uuid === web3Context.currentProvider?.info.uuid) {
                   return null;
                 }
+
                 return (
                   <div key={provider.info.uuid}>
-                    <ProviderButton provider={provider}></ProviderButton>
+                    <ProviderButton provider={provider} />
                   </div>
                 );
               })}
             </>
-          ) : null}
+          )}
 
           <h2>Network Details</h2>
-          <div>Chain ID: {`${chainId}`}</div>
-          <div>Network ID: {`${networkId}`}</div>
+          {chainId && <div>Chain ID: {`${chainId}`}</div>}
+          {networkId && <div>Network ID: {`${networkId}`}</div>}
 
           <AccountProvider>
             <Accounts />
@@ -94,6 +121,7 @@ function App() {
           </div>
         </>
       )}
+
       <br />
       <i>
         This project was bootstrapped with{' '}

--- a/packages/example-react-app/src/index.tsx
+++ b/packages/example-react-app/src/index.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import App from './App';
+
 import { Web3Provider } from './web3/Web3Context';
+import App from './App';
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(

--- a/packages/example-react-app/src/wallet-components/AddEthereumChain.tsx
+++ b/packages/example-react-app/src/wallet-components/AddEthereumChain.tsx
@@ -1,5 +1,6 @@
 import { useContext, useState } from 'react';
-import { AddEthereumChainRequest } from 'web3-plugin-wallet-rpc';
+import type { AddEthereumChainRequest } from 'web3-plugin-wallet-rpc';
+
 import { Web3Context } from '../web3/Web3Context';
 
 const chains: Record<string, AddEthereumChainRequest> = {
@@ -56,7 +57,7 @@ function AddChainButton({ chainDetails }: { chainDetails: AddEthereumChainReques
   return (
     <>
       <button type="button" onClick={handleClick}>
-        {`Add new chain: ${chainDetails.chainName} (${chainDetails.chainId})`}
+        {`Add new chain: ${chainDetails.chainName ?? ''} (${chainDetails.chainId})`}
       </button>
       {error && <div>{error.message}</div>}
     </>

--- a/packages/example-react-app/src/wallet-components/GetPermissions.tsx
+++ b/packages/example-react-app/src/wallet-components/GetPermissions.tsx
@@ -1,5 +1,6 @@
 import { useContext, useState } from 'react';
-import { Permission } from 'web3-plugin-wallet-rpc';
+import type { Permission } from 'web3-plugin-wallet-rpc';
+
 import { Web3Context } from '../web3/Web3Context';
 
 export function GetPermissions() {
@@ -12,7 +13,7 @@ export function GetPermissions() {
       .getPermissions()
       .then((response) => {
         // eslint-disable-next-line no-console
-        console.log(`Successfully got permissions with response`, response);
+        console.log('Successfully got permissions with response', response);
 
         setPermissions(response);
       })

--- a/packages/example-react-app/src/wallet-components/RequestPermissions.tsx
+++ b/packages/example-react-app/src/wallet-components/RequestPermissions.tsx
@@ -1,5 +1,6 @@
 import { useContext, useState } from 'react';
-import { Permission } from 'web3-plugin-wallet-rpc';
+import type { Permission } from 'web3-plugin-wallet-rpc';
+
 import { Web3Context } from '../web3/Web3Context';
 
 export function RequestPermissions() {
@@ -14,7 +15,7 @@ export function RequestPermissions() {
       })
       .then((response) => {
         // eslint-disable-next-line no-console
-        console.log(`Successfully requested permissions with response`, response);
+        console.log('Successfully requested permissions with response', response);
 
         setPermissions(response);
       })

--- a/packages/example-react-app/src/wallet-components/RevokePermissions.tsx
+++ b/packages/example-react-app/src/wallet-components/RevokePermissions.tsx
@@ -1,4 +1,5 @@
 import { useContext, useState } from 'react';
+
 import { Web3Context } from '../web3/Web3Context';
 
 export function RevokePermissions() {
@@ -12,7 +13,7 @@ export function RevokePermissions() {
       })
       .then((response) => {
         // eslint-disable-next-line no-console
-        console.log(`Successfully revoked permissions with response`, response);
+        console.log('Successfully revoked permissions with response', response);
       })
       .catch((e) => {
         // eslint-disable-next-line no-console

--- a/packages/example-react-app/src/wallet-components/WatchAsset.tsx
+++ b/packages/example-react-app/src/wallet-components/WatchAsset.tsx
@@ -1,5 +1,6 @@
 import { useContext, useState } from 'react';
-import { WatchAssetRequest } from 'web3-plugin-wallet-rpc';
+import type { WatchAssetRequest } from 'web3-plugin-wallet-rpc';
+
 import { Web3Context } from '../web3/Web3Context';
 
 const tokens: Record<string, WatchAssetRequest> = {
@@ -21,7 +22,10 @@ function WatchAssetButton({ asset }: { asset: WatchAssetRequest }) {
       .watchAsset(asset)
       .then((response) => {
         // eslint-disable-next-line no-console
-        console.log(`Successfully added ${asset.options.symbol} with response`, response);
+        console.log(
+          `Successfully added ${asset.options.symbol ?? ''} with response`,
+          response,
+        );
       })
       .catch((e) => {
         // eslint-disable-next-line no-console
@@ -46,7 +50,7 @@ function WatchAssetButton({ asset }: { asset: WatchAssetRequest }) {
 export function WatchAsset() {
   return (
     <div>
-      <h4>Add token to wallet's list</h4>
+      <h4>Add token to wallet&apos;s list</h4>
       <WatchAssetButton asset={tokens.usdc} />
     </div>
   );

--- a/packages/example-react-app/src/web3/Web3Context.tsx
+++ b/packages/example-react-app/src/web3/Web3Context.tsx
@@ -6,23 +6,26 @@ import {
   useMemo,
   useState,
 } from 'react';
-import { providers, Web3 } from 'web3';
+import type { EIP6963ProviderDetail } from 'web3';
+import { Web3 } from 'web3';
 import { WalletRpcPlugin } from 'web3-plugin-wallet-rpc';
+
 import { useProviders } from './useProviders';
 
-export interface IWeb3Context {
+export type IWeb3Context = {
   web3: Web3;
-  providers: providers.EIP6963ProviderDetail[];
-  currentProvider: providers.EIP6963ProviderDetail | undefined;
-  setCurrentProvider: (provider: providers.EIP6963ProviderDetail) => void;
-}
+  providers: EIP6963ProviderDetail[];
+  currentProvider: EIP6963ProviderDetail | undefined;
+  setCurrentProvider: (provider: EIP6963ProviderDetail) => void;
+};
 
 const defaultContext: IWeb3Context = {
   web3: new Web3(),
   providers: [],
   currentProvider: undefined,
-  setCurrentProvider: function (provider: providers.EIP6963ProviderDetail): void {
+  setCurrentProvider(provider: EIP6963ProviderDetail): void {
     this.web3.setProvider(provider.provider);
+
     this.currentProvider = provider;
   },
 };
@@ -34,22 +37,26 @@ export const Web3Context = createContext<IWeb3Context>(defaultContext);
  * @param children components that may require access to an instance of Web3.js
  * @returns React component that provides a context for interacting with a shared, managed instance of Web3.js
  */
-export const Web3Provider = ({ children }: { children: ReactNode }) => {
+export function Web3Provider({ children }: { children: ReactNode }) {
   const web3: Web3 = useMemo(() => {
-    const web3 = new Web3();
-    web3.registerPlugin(new WalletRpcPlugin());
-    return web3;
+    const tempWeb3 = new Web3();
+    tempWeb3.registerPlugin(new WalletRpcPlugin());
+
+    return tempWeb3;
   }, []);
-  const providers: providers.EIP6963ProviderDetail[] = useProviders();
+
+  const providers: EIP6963ProviderDetail[] = useProviders();
 
   const [currentProvider, _setCurrentProvider] = useState<
-    providers.EIP6963ProviderDetail | undefined
+    EIP6963ProviderDetail | undefined
   >(undefined);
 
   const setCurrentProvider = useCallback(
-    (provider: providers.EIP6963ProviderDetail) => {
+    (provider: EIP6963ProviderDetail) => {
       web3.setProvider(provider.provider);
+
       localStorage.setItem('provider', provider.info.rdns);
+
       _setCurrentProvider(provider);
     },
     [web3],
@@ -66,9 +73,8 @@ export const Web3Provider = ({ children }: { children: ReactNode }) => {
       return;
     }
 
-    const targetProvider: providers.EIP6963ProviderDetail | undefined = providers.find(
-      (provider: providers.EIP6963ProviderDetail) =>
-        provider.info.rdns === cachedProvider,
+    const targetProvider: EIP6963ProviderDetail | undefined = providers.find(
+      (provider: EIP6963ProviderDetail) => provider.info.rdns === cachedProvider,
     );
 
     if (targetProvider !== undefined) {
@@ -76,12 +82,15 @@ export const Web3Provider = ({ children }: { children: ReactNode }) => {
     }
   }, [currentProvider, providers, setCurrentProvider]);
 
-  const web3Context: IWeb3Context = {
-    web3,
-    providers,
-    currentProvider,
-    setCurrentProvider,
-  };
+  const web3Context = useMemo<IWeb3Context>(
+    () => ({
+      web3,
+      providers,
+      currentProvider,
+      setCurrentProvider,
+    }),
+    [web3, providers, currentProvider, setCurrentProvider],
+  );
 
   return <Web3Context.Provider value={web3Context}>{children}</Web3Context.Provider>;
-};
+}

--- a/packages/example-react-app/src/web3/useProviders.ts
+++ b/packages/example-react-app/src/web3/useProviders.ts
@@ -1,7 +1,12 @@
 import { useSyncExternalStore } from 'react';
-import { providers, Web3 } from 'web3';
+import type {
+  EIP6963ProviderDetail,
+  EIP6963ProviderResponse,
+  EIP6963ProvidersMapUpdateEvent,
+} from 'web3';
+import { Web3 } from 'web3';
 
-let providerList: providers.EIP6963ProviderDetail[] = [];
+let providerList: EIP6963ProviderDetail[] = [];
 
 /**
  * External store for subscribing to EIP-6963 providers
@@ -10,30 +15,39 @@ let providerList: providers.EIP6963ProviderDetail[] = [];
 const providerStore = {
   getSnapshot: () => providerList,
   subscribe: (callback: () => void) => {
-    function setProviders(response: providers.EIP6963ProviderResponse) {
+    function setProviders(response: EIP6963ProviderResponse): void {
       providerList = [];
-      for (const [, provider] of response) {
+
+      response.forEach((provider) => {
         providerList.push(provider);
-      }
+      });
 
       callback();
     }
 
-    Web3.requestEIP6963Providers().then(setProviders);
+    Web3.requestEIP6963Providers()
+      .then(setProviders)
+      .catch((error) => {
+        // eslint-disable-next-line no-console
+        console.error(error);
+      });
 
-    function updateProviders(providerEvent: providers.EIP6963ProvidersMapUpdateEvent) {
+    function updateProviders(event: Event) {
+      const providerEvent = event as EIP6963ProvidersMapUpdateEvent;
       setProviders(providerEvent.detail);
     }
 
     Web3.onNewProviderDiscovered(updateProviders);
 
-    return () =>
+    return () => {
       window.removeEventListener(
-        providers.web3ProvidersMapUpdated as any,
-        updateProviders,
+        'web3:providersMapUpdated',
+        updateProviders as EventListener,
       );
+    };
   },
 };
 
 export const useProviders = () =>
+  // eslint-disable-next-line implicit-arrow-linebreak
   useSyncExternalStore(providerStore.subscribe, providerStore.getSnapshot);


### PR DESCRIPTION
The default react-scripts linter is quite lenient, so I’d like to adopt a stricter setup to enhance code quality. I found that ChainSafe’s ESLint configuration includes settings for React apps, so I’m integrating it here. However, it conflicts with some Prettier settings, which I’ve temporarily ignored in certain places. What do you think?